### PR TITLE
Change image to portainer-ce

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ cd global
 bash start.sh start
 ````
 
-## Required ENV variable
-
 These Environment variables are required for docker-global to start.
 
 ````bash
@@ -34,6 +32,12 @@ HTTPS_MAIN_DOMAIN=vm23.your.tld
 DNS_CLOUDFLARE_EMAIL=cloudflare@yourmail
 DNS_CLOUDFLARE_API_KEY=0123456789abcdefghijklmnopqrstuvwxyz
 ````
+
+Go to your Portainer URL and create a user.
+
+Configure Portainer:
+
+* Settings > Authentification > Session lifetime = 1 year
 
 ## https
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,14 +37,14 @@ services:
       - VIRTUAL_PORT=8025
 
   global-portainer:
-    image: portainer/portainer
+    image: portainer/portainer-ce
     restart: ${RESTART:-unless-stopped}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./.docker/data/global-portainer:/data
     environment:
       - VIRTUAL_HOST=portainer.${TLD_DOMAIN:?needed}
-    command: --no-auth
+      - VIRTUAL_PORT=9000
 
   global-letsencrypt:
     image: kanti/local-https


### PR DESCRIPTION
Switch to the new Portainer 2.0 (portainer-ce) image.

The authentication has changed. It looks like you need a password now. You can simply set this yourself during the first installation.

**Please test it yourself first! I haven't tested that with this repository.**

```bash
./start.sh down
rm -rf ./.docker/data/global-portainer
./start.sh up
```

Go to your Portainer URL and create a user.

Configure Portainer:

* Settings > Authentification > Session lifetime = 1 year